### PR TITLE
docs: Fix simple typo, strting -> starting

### DIFF
--- a/sandbox/simple_pagination/models.py
+++ b/sandbox/simple_pagination/models.py
@@ -21,7 +21,7 @@ class EndlessPage(utils.UnicodeMixin):
         - *self.number*: the page number;
         - *self.label*: the label of the link
           (usually the page number as string);
-        - *self.url*: the url of the page (strting with "?");
+        - *self.url*: the url of the page (starting with "?");
         - *self.path*: the path of the page;
         - *self.is_current*: return True if page is the current page displayed;
         - *self.is_first*: return True if page is the first page;
@@ -237,7 +237,7 @@ class ShowItems(utils.UnicodeMixin):
         - *self.number*: the page number;
         - *self.label*: the label of the link
           (usually the page number as string);
-        - *self.url*: the url of the page (strting with "?");
+        - *self.url*: the url of the page (starting with "?");
         - *self.path*: the path of the page;
         - *self.is_current*: return True if page is the current page displayed;
         - *self.is_first*: return True if page is the first page;

--- a/simple_pagination/models.py
+++ b/simple_pagination/models.py
@@ -21,7 +21,7 @@ class EndlessPage(utils.UnicodeMixin):
         - *self.number*: the page number;
         - *self.label*: the label of the link
           (usually the page number as string);
-        - *self.url*: the url of the page (strting with "?");
+        - *self.url*: the url of the page (starting with "?");
         - *self.path*: the path of the page;
         - *self.is_current*: return True if page is the current page displayed;
         - *self.is_first*: return True if page is the first page;
@@ -237,7 +237,7 @@ class ShowItems(utils.UnicodeMixin):
         - *self.number*: the page number;
         - *self.label*: the label of the link
           (usually the page number as string);
-        - *self.url*: the url of the page (strting with "?");
+        - *self.url*: the url of the page (starting with "?");
         - *self.path*: the path of the page;
         - *self.is_current*: return True if page is the current page displayed;
         - *self.is_first*: return True if page is the first page;


### PR DESCRIPTION
There is a small typo in sandbox/simple_pagination/models.py, simple_pagination/models.py.

Should read `starting` rather than `strting`.

